### PR TITLE
Fix rendering when a message contents contain something other than a string

### DIFF
--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -29,7 +29,8 @@ class Message extends Component {
   }
   process (msg, action, color) {
     // process markdown and emojis
-    const emojified = emoji.emojify(msg, null, (e) => `[${e}]{.emoji}`)
+    const msgStr = typeof msg === 'string' ? msg : JSON.stringify(msg)
+    const emojified = emoji.emojify(msgStr, null, (e) => `[${e}]{.emoji}`)
     let input = this.markMentions(emojified)
     input = this.makeSpansSafe(input)
     const marked = remark()


### PR DESCRIPTION
A message contents contained an object rather than a string which threw errors
on emojification blocking further rendering.